### PR TITLE
Fix sitemap URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,11 @@ languageCode = "en-us"
 theme = "hello-friend"
 paginate = 5
 
+[sitemap]
+  changefreq = "monthly"
+  filename = "sitemap.xml"
+  priority = 0.5
+
 [params]
   # dir name of your blog content (default is `content/posts`)
   contentTypeName = "posts"

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,22 @@
+
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+  {{ end }}
+</urlset>


### PR DESCRIPTION
This is my attempt to fix the errors @aabatangle found with the blog's sitemap. I think the issue is the `loc` item not have an absolute URL.

Before: https://www.xml-sitemaps.com/validate-xml-sitemap.html?op=validate-xml-sitemap&go=1&sitemapurl=blog.netdata.cloud%2Fsitemap.xml&submit=Validate+Sitemap

```
<urlset>
<url>
<loc>/posts/netdata-culture-people/</loc>
<lastmod>2020-03-20T13:05:52-07:00</lastmod>
</url>
<url>
<loc>/posts/contribute-machine-learning/</loc>
<lastmod>2020-03-13T06:20:37-07:00</lastmod>
</url>
```

After: https://www.xml-sitemaps.com/validate-xml-sitemap.html?op=validate-xml-sitemap&go=1&sitemapurl=https%3A%2F%2Fdeploy-preview-61--netdata-blog.netlify.com%2Fsitemap.xml&submit=Validate+Sitemap

```
<urlset>
<url>
<loc>
https://deploy-preview-61--netdata-blog.netlify.com/posts/netdata-culture-people/
</loc>
<lastmod>2020-03-23T00:00:00+00:00</lastmod>
<changefreq>monthly</changefreq>
<priority>0.5</priority>
</url>
<url>
<loc>
https://deploy-preview-61--netdata-blog.netlify.com/posts/contribute-machine-learning/
</loc>
<lastmod>2020-03-16T00:00:00+00:00</lastmod>
<changefreq>monthly</changefreq>
<priority>0.5</priority>
</url>
```