### PR TITLE
update referrer policy in header for better subdomain insights

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Referrer-Policy = "no-referrer-when-downgrade"
+
 [[redirects]]
   from = "/posts/redefining-monitoring-netdata"
   to = "/redefining-monitoring-with-netdata"


### PR DESCRIPTION
- this pr adds `Referrer-Policy: no-referrer-when-downgrade` header so we can see url path from where users are coming from when they move from one of our subdomains to another one.